### PR TITLE
fixes to container margins

### DIFF
--- a/src/components/AboutUsPage/AboutPage.css
+++ b/src/components/AboutUsPage/AboutPage.css
@@ -6,6 +6,7 @@
    color: white;
     margin-top: 30px;
     padding: 0 72px;
+    
 }
 
 .about-us-top p {
@@ -44,10 +45,12 @@
     flex-direction: column;
     width: 95%;
     margin: 0 auto;
-    
+   
     flex-wrap: nowrap; 
+   
 
 }
+
 
 .gallery-container .row-1, .gallery-container .row-2 {
     display: flex;
@@ -55,8 +58,9 @@
     width: 100%;
     display: flex;
     align-items: center; 
-    height: 100%;
- 
+    
+   
+
    
 }
 
@@ -73,15 +77,17 @@
     background-color: rgba(255, 255, 255, 0.10);
     flex-wrap: nowrap; 
     margin-bottom: 50px;
+   
 }
 
 /* Fix for the nested gal-items-container issue */
 .gallery-items-container {
     display: grid;
     grid-template-columns: repeat(3, 1fr); /* Maximum of 3 items per row */
-    height: 100%;
+    column-gap: 70px;
     
-    margin-bottom: 5%;
+    
+
   
 }
 
@@ -94,20 +100,22 @@ becuase there appears to be differnet defualt spacing on them */
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 15%;
+
     margin-top: 2%;
+    padding-bottom:18%;  /* Temporary, gives slighly more space to top compensationg for less content*/
    
 }
 .gallery-item2 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 15%;
+    padding-bottom:15%;
+  
     margin-top: 2%;
    
 }
 
-
+ 
 /* Ensure the images are consistent */
 .gallery-item1 img, .gallery-item2 img {
     width: 200px;


### PR DESCRIPTION
Issue: about us container would stick to the bottom of the page and had no margin between it and the footer, upon resizing the window, the margin would appear. This pr fixes this issue