### PR TITLE
added back overwritten event type tag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ function App() {
         <Routes >
           <Route path="/" element={<HomeView />} />
           <Route path="/event-types" element={<EventTypes />} />
+          <Route path="/event-types/:tag?" element={<EventTypes />} />
           <Route path="/event-calendar" element={<EventCalPage />} />
           <Route path="/about-us" element={<AboutUsPage />} />
           <Route path="/blog" element={<Blog />} />


### PR DESCRIPTION
The anchor tag url  in app.jsx was overwritten by a later PR conflict resolution, fixing here